### PR TITLE
feat: CLIN-4402 bump version to 1.0.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-J
 - [ ] This comment contains a description of changes (with reason).
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/cnv-post-processing/tree/main/.github/CONTRIBUTING.md))
-- [ ] Make sure your code lints (`nf-core pipelines lint`).
+- [ ] Make sure your code lints (`nf-core pipelines lint --release`).
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
 - [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
 - [ ] Usage Documentation in `docs/usage.md` is updated.

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -41,7 +41,7 @@ jobs:
           GITHUB_COMMENTS_URL: ${{ github.event.pull_request.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_COMMIT: ${{ github.event.pull_request.head.sha }}
-        run: nf-core -l lint_log.txt pipelines lint --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
+        run: nf-core -l lint_log.txt pipelines lint --release --dir ${GITHUB_WORKSPACE} --markdown lint_results.md
 
       - name: Save PR number
         if: ${{ always() }}

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -4,50 +4,50 @@ nf_core_version: 3.2.0
 
 lint:
   files_unchanged:
-    - docs/README.md
-    - .github/CONTRIBUTING.md
-    - .github/ISSUE_TEMPLATE/bug_report.yml
-    - .github/PULL_REQUEST_TEMPLATE.md
-    - .github/workflows/linting.yml
-    - .prettierignore
-    - LICENSE
+  - docs/README.md
+  - .github/CONTRIBUTING.md
+  - .github/ISSUE_TEMPLATE/bug_report.yml
+  - .github/PULL_REQUEST_TEMPLATE.md
+  - .github/workflows/linting.yml
+  - .prettierignore
+  - LICENSE
 
   nextflow_config:
-    - manifest.name
-    - manifest.homePage
-    - validation.help.beforeText
-    - validation.help.afterText
-    - validation.summary.beforeText
-    - validation.summary.afterText
-    - config_defaults:
-        - params.exomiser_analysis_wes # projectDir variable not rendered is causing mismatch with nextflow.config
-        - params.exomiser_analysis_wgs  # projectDir variable not rendered is causing mismatch with nextflow.config
+  - manifest.name
+  - manifest.homePage
+  - validation.help.beforeText
+  - validation.help.afterText
+  - validation.summary.beforeText
+  - validation.summary.afterText
+  - config_defaults:
+    - params.exomiser_analysis_wes     # projectDir variable not rendered is causing mismatch with nextflow.config
+    - params.exomiser_analysis_wgs      # projectDir variable not rendered is causing mismatch with nextflow.config
 
   multiqc_config: false
 
   files_exist:
-    - assets/email_template.html
-    - assets/email_template.txt
-    - assets/multiqc_config.yml
-    - assets/nf-core-cnv-post-processing_logo_light.png
-    - assets/sendmail_template.txt
-    - CODE_OF_CONDUCT.md
-    - conf/igenomes.config
-    - conf/igenomes_ignored.config
-    - docs/images/nf-core-cnv-post-processing_logo_light.png
-    - docs/images/nf-core-cnv-post-processing_logo_dark.png
-    - .github/.dockstore.yml
-    - .github/ISSUE_TEMPLATE/bug_report.yml
-    - .github/ISSUE_TEMPLATE/config.yml
-    - .github/ISSUE_TEMPLATE/feature_request.yml
-    - .github/workflows/awstest.yml
-    - .github/workflows/awsfulltest.yml
-    - .github/workflows/branch.yml
-    - .github/workflows/linting_comment.yml
-    - ro-crate-metadata.json
+  - assets/email_template.html
+  - assets/email_template.txt
+  - assets/multiqc_config.yml
+  - assets/nf-core-cnv-post-processing_logo_light.png
+  - assets/sendmail_template.txt
+  - CODE_OF_CONDUCT.md
+  - conf/igenomes.config
+  - conf/igenomes_ignored.config
+  - docs/images/nf-core-cnv-post-processing_logo_light.png
+  - docs/images/nf-core-cnv-post-processing_logo_dark.png
+  - .github/.dockstore.yml
+  - .github/ISSUE_TEMPLATE/bug_report.yml
+  - .github/ISSUE_TEMPLATE/config.yml
+  - .github/ISSUE_TEMPLATE/feature_request.yml
+  - .github/workflows/awstest.yml
+  - .github/workflows/awsfulltest.yml
+  - .github/workflows/branch.yml
+  - .github/workflows/linting_comment.yml
+  - ro-crate-metadata.json
 
   readme:
-    - nextflow_badge
+  - nextflow_badge
 
   actions_ci: false
   pipeline_name_conventions: false
@@ -57,22 +57,21 @@ template:
   name: cnv-post-processing
   description: Nextflow pipeline dedicated to the post-processing of Copy Number Variants
     (CNVs).
-  author: "Lysiane Bouchard, Georgette Femerling, F\xE9lix-Antoine Le Sieur, David\
-    \ Morais"
-  version: 1.0.0dev
+  author: "Lysiane Bouchard, Georgette Femerling, Félix-Antoine Le Sieur, David Morais"
+  version: 1.0.0
   force: true
   outdir: .
   skip_features:
-    - igenomes
-    - github_badges
-    - gitpod
-    - codespaces
-    - multiqc
-    - fastqc
-    - email
-    - adaptivecard
-    - slackreport
-    - seqera_platform
-    - rocrate
-    - vscode
+  - igenomes
+  - github_badges
+  - gitpod
+  - codespaces
+  - multiqc
+  - fastqc
+  - email
+  - adaptivecard
+  - slackreport
+  - seqera_platform
+  - rocrate
+  - vscode
   is_nfcore: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unrelease
+## Unreleased
+
+## v1.0.0 - 2025-05-01
 
 Initial release of Ferlab-Ste-Justine/cnv-post-processing, created with the [nf-core](https://nf-co.re/) template.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -257,7 +257,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
     nextflowVersion = '!>=23.10.1'
-    version         = '1.0.0dev'
+    version         = '1.0.0'
     doi             = ''
 }
 


### PR DESCRIPTION
This PR updates the version from 1.0.0dev to 1.0.0.

Since we are no longer using development (dev) versions, the linter command was adjusted to prevent warnings about the missing "dev" tag.

Note: The `.nf-core.yml` file appears to have been reindented. This change was likely caused by the nf-core pipelines bump-version command or possibly by my code editor.

<!--
# Ferlab-Ste-Justine/cnv-post-processing pull request

Many thanks for contributing to Ferlab-Ste-Justine/cnv-post-processing!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the main branch.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Ferlab-Ste-Justine/cnv-post-processing/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Ferlab-Ste-Justine/cnv-post-processing/tree/main/.github/CONTRIBUTING.md))
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] Reference Data Documentation in `docs/reference_data.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
